### PR TITLE
シーン移行時のアイテムのDestroyバグの修正

### DIFF
--- a/Misoten_MainProject/Assets/Demo/Programmer/Amano/komono/Break_obj/Dropitem_cutmaterial.cs
+++ b/Misoten_MainProject/Assets/Demo/Programmer/Amano/komono/Break_obj/Dropitem_cutmaterial.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using Unity.VisualScripting;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public class Dropitem_cutmaterial : MonoBehaviour
 {
@@ -20,29 +21,25 @@ public class Dropitem_cutmaterial : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-
-
-
-    }
+     }
 
     // Update is called once per frame
     void Update()
     {
-
+       
     }
 
-    private void OnDestroy()
+    public void CreateItem()
     {
         if (droping_item != null)
         {
             GameObject prefab = Resources.Load<GameObject>(droping_item.name);
-            GameObject drop_new = Instantiate(droping_item, new Vector3(this.transform.position.x,this.transform.position.y+3.0f,this.transform.position.z), Quaternion.identity,gameObject.transform.parent);
+            GameObject drop_new = Instantiate(droping_item, new Vector3(this.transform.position.x, this.transform.position.y + 3.0f, this.transform.position.z), Quaternion.identity, gameObject.transform.parent);
 
             Instantiate(item_particle, transform.position, vector_particle);
 
             Debug.Log(droping_item.name);
 
         }
-
     }
 }

--- a/Misoten_MainProject/Assets/Demo/Programmer/Amano/komono/test_sword.cs
+++ b/Misoten_MainProject/Assets/Demo/Programmer/Amano/komono/test_sword.cs
@@ -81,6 +81,8 @@ public class TestSword : MonoBehaviour
                 MakeItPhysical(upperHull, other.transform);
                 MakeItPhysical(lowerHull, other.transform);
 
+                targetObject.GetComponent<Dropitem_cutmaterial>().CreateItem();
+
                 // 元のオブジェクトを削除
                 Destroy(targetObject);
                 audioSource_S.PlayOneShot(AudioClip_Slash);

--- a/Misoten_MainProject/Assets/Scene/Main/Main_Stage01.unity
+++ b/Misoten_MainProject/Assets/Scene/Main/Main_Stage01.unity
@@ -3647,6 +3647,11 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 7309694239314744269, guid: 8eb4fdc726e23774da71f86d9d295d96,
+        type: 3}
+      propertyPath: m_TagString
+      value: Untagged
+      objectReference: {fileID: 0}
     - target: {fileID: 7402921998873306554, guid: 8eb4fdc726e23774da71f86d9d295d96,
         type: 3}
       propertyPath: m_Enabled


### PR DESCRIPTION
test_sword内でアイテムの生成をする場所を追加してDestroy環境下でのそうさをしないようにする